### PR TITLE
feat: add setting for custom webchatroot div element

### DIFF
--- a/src/common/interfaces/webchat-config.ts
+++ b/src/common/interfaces/webchat-config.ts
@@ -409,6 +409,7 @@ export interface IWebchatSettings {
 			timeout: number;
 			title: string;
 		};
+		webchatRoot: string;
 	};
 
 	// Additional Settings to configure the webchat widget behavior

--- a/src/webchat-embed/index.tsx
+++ b/src/webchat-embed/index.tsx
@@ -74,9 +74,20 @@ const initWebchat = async (
 		...settings?.embeddingConfiguration,
 		_endpointTokenUrl: webchatConfigUrl,
 	} as Partial<IWebchatSettings>["embeddingConfiguration"];
-	const webchatRoot = document.createElement("div");
-	document.body.appendChild(webchatRoot);
-
+	let webchatRoot = document.createElement("div");
+	
+	// Check if a custom webchat root is provided in the settings and use it if available
+	// If not found or if it's no div element just use the default webchatRoot
+	let customWebchatRoot: unknown = null;
+	if (settings?.embeddingConfiguration?.webchatRoot && settings.embeddingConfiguration.webchatRoot !== "") {
+		customWebchatRoot = document.getElementById(settings.embeddingConfiguration.webchatRoot);
+	}
+	if (customWebchatRoot && customWebchatRoot instanceof HTMLDivElement) {
+		webchatRoot = customWebchatRoot as HTMLDivElement;
+	} else {
+		document.body.appendChild(webchatRoot);
+	}
+	
 	let cognigyWebchat: Webchat | null = null;
 
 	const root = createRoot(webchatRoot);


### PR DESCRIPTION
# Success criteria

- The Webchat is normally put into a new <div> element in the root of the page loading the script. This PR makes it possible to provide an existing <div> element where the Webchat will be put in.

# How to test

1. Create a <div> element with a unique id
2. Supply the "webchatRoot" setting under the "embeddingConfiguration" with the unique id
3. The Webchat will be created in this <div> instead in a new <div> in the root of the page
4. If the provided container isn't found or is no <div> then the fallback behavior is a new <div> in the root

# Security

- [X] No security implications
