### PR TITLE
Add home button for "Login and start chat"

### DIFF
--- a/src/common/interfaces/login-handler.ts
+++ b/src/common/interfaces/login-handler.ts
@@ -1,0 +1,3 @@
+export interface LoginHandler {
+    (userId: string, sessionId: string): void;
+}

--- a/src/common/interfaces/webchat-config.ts
+++ b/src/common/interfaces/webchat-config.ts
@@ -1,3 +1,5 @@
+import { LoginHandler } from "./login-handler";
+
 export type TSourceDirection = "incoming" | "outgoing";
 export type TSourceColorV2 = "primary" | "neutral";
 export type TSourceColor = "bot" | "user";
@@ -220,12 +222,11 @@ export interface IWebchatSettings {
 			color: string;
 		};
 		startConversationButtonText: string;
-		loginAndStartConversation: {
+		loginAndStartConversationButton: {
 			enabled: boolean;
 			buttonText: string;
-			url?: string;
-			handler?: string;
-			payload?: string;
+			type: "web_url" | "handler";
+			payload: string | LoginHandler;
 		};
 		previousConversations: {
 			startNewConversationButtonText: string;

--- a/src/common/interfaces/webchat-config.ts
+++ b/src/common/interfaces/webchat-config.ts
@@ -220,6 +220,13 @@ export interface IWebchatSettings {
 			color: string;
 		};
 		startConversationButtonText: string;
+		loginAndStartConversation: {
+			enabled: boolean;
+			buttonText: string;
+			url?: string;
+			handler?: string;
+			payload?: string;
+		};
 		previousConversations: {
 			startNewConversationButtonText: string;
 			enableDeleteAllConversations?: boolean;

--- a/src/webchat-ui/components/presentational/HomeScreen.tsx
+++ b/src/webchat-ui/components/presentational/HomeScreen.tsx
@@ -162,6 +162,7 @@ interface IHomeScreenProps {
 	onEmitAnalytics: WebchatUIProps["onEmitAnalytics"];
 	onSendActionButtonMessage: WebchatUIProps["onSendMessage"];
 	onStartConversation: () => void;
+	onLoginAndStartConversation: () => void;
 }
 
 export const HomeScreen: React.FC<IHomeScreenProps> = props => {
@@ -175,6 +176,7 @@ export const HomeScreen: React.FC<IHomeScreenProps> = props => {
 		onEmitAnalytics,
 		onSendActionButtonMessage,
 		onStartConversation,
+		onLoginAndStartConversation
 	} = props;
 
 	const homeScreenRef = useRef<HTMLDivElement>(null);
@@ -269,6 +271,15 @@ export const HomeScreen: React.FC<IHomeScreenProps> = props => {
 				)}
 			</HomeScreenContent>
 			<HomeScreenActions className="webchat-homescreen-actions">
+				{config.settings.homeScreen.loginAndStartConversationButton.enabled && (
+					<StartButton
+						onClick={onLoginAndStartConversation}
+						className="webchat-homescreen-send-button"
+						data-test="webchat-start-chat-button"
+					>
+						{config.settings.homeScreen.loginAndStartConversationButton.buttonText || "Login and start conversation"}
+					</StartButton>
+				)}
 				<StartButton
 					onClick={onStartConversation}
 					className="webchat-homescreen-send-button"

--- a/src/webchat/store/config/config-reducer.ts
+++ b/src/webchat/store/config/config-reducer.ts
@@ -96,6 +96,7 @@ export const getInitialState = (): ConfigState => ({
 				enabled: true,
 				buttonText: "Previous conversations",
 				title: "",
+				startNewConversationButtonText: ""
 			},
 			conversationStarters: {
 				enabled: true,

--- a/src/webchat/store/config/config-reducer.ts
+++ b/src/webchat/store/config/config-reducer.ts
@@ -102,9 +102,11 @@ export const getInitialState = (): ConfigState => ({
 				enabled: true,
 				starters: [],
 			},
-			loginAndStartConversation: {
+			loginAndStartConversationButton: {
 				enabled: false,
 				buttonText: "Login and start conversation",
+				type: "web_url",
+				payload: "",
 			},
 		},
 		teaserMessage: {

--- a/src/webchat/store/config/config-reducer.ts
+++ b/src/webchat/store/config/config-reducer.ts
@@ -173,6 +173,7 @@ Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 
 				timeout: 2000,
 				title: "",
 			},
+			webchatRoot: "",
 		},
 
 		// Additional Settings to configure the webchat widget behavior

--- a/src/webchat/store/config/config-reducer.ts
+++ b/src/webchat/store/config/config-reducer.ts
@@ -102,6 +102,10 @@ export const getInitialState = (): ConfigState => ({
 				enabled: true,
 				starters: [],
 			},
+			loginAndStartConversation: {
+				enabled: false,
+				buttonText: "Login and start conversation",
+			},
 		},
 		teaserMessage: {
 			text: "",


### PR DESCRIPTION
# Success criteria

- Configurable in settings to show an additional button for "Login and start chat" on home screen
- The action can be either a web_url to jump to or a LoginHandler function that will be called when the button is pressed

# How to test

1. Add the settings.homeScreen.loginAndStartConversationButton setting and start the chat

# Security

- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [X] No security implications
